### PR TITLE
Add python 3.11 and 3.10 Support, Drop python 3.6 and 3.7

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -7,29 +7,26 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'Action to perform'
+        description: "Action to perform"
         required: true
-        default: 'Deploy to PyPI & Create GitHub Release'
+        default: "Deploy to PyPI & Create GitHub Release"
 
 jobs:
-
   # Runs all steps on the VM
   test:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        os: [ubuntu-22.04, macos-14, windows-2022]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
-
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -51,21 +48,20 @@ jobs:
   # Runs all steps on the VM
   # Deploy to PyPI & create a GitHub Release when the test job succeeds, and only on pushes to tags.
   deploy:
-
     needs: test
 
     if: needs.test.result == 'success' && startsWith( github.ref, 'refs/tags/v' )
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
 
       - name: Install Dependencies
         run: |
@@ -109,7 +105,7 @@ jobs:
           invoke get-release-notes
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.get_release_title.outputs.RELEASE_NAME }}
           body_path: ../LATEST_RELEASE_NOTES.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,24 +15,21 @@ on:
       - "v*"
 
 jobs:
-
   # Runs all steps on the VM
   test:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        os: [ubuntu-22.04, macos-14, windows-2022]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
-
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -54,21 +51,20 @@ jobs:
   # Runs all steps on the VM
   # Deploy to PyPI & create a GitHub Release when the test job succeeds, and only on pushes to tags.
   deploy:
-
     needs: test
 
     if: needs.test.result == 'success' && startsWith( github.ref, 'refs/tags/v' )
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
 
       - name: Install Dependencies
         run: |
@@ -112,7 +108,7 @@ jobs:
           invoke get-release-notes
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.get_release_title.outputs.RELEASE_NAME }}
           body_path: ../LATEST_RELEASE_NOTES.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.6.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=5000']
@@ -18,12 +18,12 @@ repos:
         exclude: .git/COMMIT_EDITMSG
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 24.4.2
     hooks:
     -   id: black
         exclude: (.*)/migrations
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 7.1.0
   hooks:
     - id: flake8
 -   repo: https://github.com/asottile/seed-isort-config
@@ -31,7 +31,7 @@ repos:
     hooks:
     -   id: seed-isort-config
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.13.2
     hooks:
     -   id: isort
         args: ["--profile", "black"]
@@ -40,12 +40,12 @@ repos:
 #     hooks:
 #     - id: bandit
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: v2.18.0
+  rev: v3.27.0
   hooks:
     - id: commitizen
       stages: [commit-msg]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.910'  # Use the sha / tag you want to point at
+    rev: 'v1.10.1'  # Use the sha / tag you want to point at
     hooks:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 
-Copyright (c) 2021, Victor Miti
+Copyright (c) 2021 - present, Victor Miti
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [Why this project?](#why-this-project)
 - [Features](#features)
@@ -91,7 +92,7 @@ If what you're looking for is a powerful, _general purpose badge generation tool
 
 - automatically generates your project's coverage badge using the [shields.io](https://shields.io/) service, and then updates your project's README with the newly generated badge
 - simple CLI tool (`readme-cov`) with helpful messages
-- tested on python 3.6 to 3.9 with coverage ≥ 84%
+- tested on python 3.8 to 3.12 with coverage ≥ 84%
 - free software: BSD-3-Clause license
 - generates different colours depending on the coverage percentage. Optionally generate plain colour (green) regardless of percentage
 - minimal external dependencies – this tool only has 2 external dependencies; [Coverage.py](https://github.com/nedbat/coveragepy) (obviously!) and [colorama](https://github.com/tartley/colorama) (for cross-platform coloured terminal output)
@@ -99,7 +100,7 @@ If what you're looking for is a powerful, _general purpose badge generation tool
 The table below shows the coverage thresholds, associated colours and examples of generated badges:
 
 | Coverage            | Colour      | Example                                                                                    |
-|---------------------|-------------|--------------------------------------------------------------------------------------------|
+| ------------------- | ----------- | ------------------------------------------------------------------------------------------ |
 | 0 ≤ coverage < 40   | red         | ![Code Coverage Red ](https://img.shields.io/badge/Coverage-13%25-red.svg)                 |
 | 40 ≤ coverage < 60  | orange      | ![Code Coverage Orange ](https://img.shields.io/badge/Coverage-46%25-orange.svg)           |
 | 60 ≤ coverage < 75  | yellow      | ![Code Coverage Yellow ](https://img.shields.io/badge/Coverage-69%25-yellow.svg)           |
@@ -130,7 +131,7 @@ The tool operates on the basis of the following assumptions:
 
 - you have a README.md or README file at the root of your project
 - your README file is in markdown format. I know, some Pythonistas prefer restructuredtext! Sadly, this isn't supported (yet)
-- Somewhere in your your README is a string in the form: `![Code Coverage]()` or `![Code Coverage](anything here)`. This is what gets updated in-place (using [`re.sub()`](https://docs.python.org/3.8/library/re.html#re.sub)) when the script runs.
+- Somewhere in your your README is a string in the form: `![Code Coverage]()` or `![Code Coverage](anything here)`. This is what gets updated in-place (using [`re.sub()`](https://docs.python.org/3.12/library/re.html#re.sub)) when the script runs.
 - the script is called from the root of your project repo, which has coverage.py already configured, and the coverage already updated (you have already run your tests prior to running the script)
 - If the coverage badge in your README file is already up to date, your README file won't be updated, you will only be notified
 
@@ -138,7 +139,7 @@ The tool operates on the basis of the following assumptions:
 
 ### First things first
 
-- ensure that you have [Python 3.6+](https://www.python.org/) on your machine, and that you are able to configure python [**virtual environment**](https://realpython.com/python-virtual-environments-a-primer/)s.
+- ensure that you have [Python 3.8+](https://www.python.org/) on your machine, and that you are able to configure python [**virtual environment**](https://realpython.com/python-virtual-environments-a-primer/)s.
 - ensure that you have [git](https://git-scm.com/) setup on your machine.
 
 ### Getting Started
@@ -174,7 +175,7 @@ Test other Python versions by running `tox`.
 
 👤 **Victor Miti**
 
-- Blog: <https://importthis.tech>
+- Blog: <https://blog.victor.co.zm>
 - Twitter: [![Twitter: engineervix](https://img.shields.io/twitter/follow/engineervix.svg?style=social)](https://twitter.com/engineervix)
 - Github: [@engineervix](https://github.com/engineervix)
 
@@ -187,7 +188,7 @@ Feel free to check the [issues page](https://github.com/engineervix/readme-cover
 - if you're making code contributions, please try and write some tests to accompany your code, and ensure that the tests pass. Also, were necessary, update the docs so that they reflect your changes.
 - commit your changes via `cz commit`. Follow the prompts. When you're done, `pre-commit` will be invoked to ensure that your contributions and commits follow defined conventions. See `pre-commit-config.yaml` for more details.
 - your commit messages should follow the conventions described [here](https://www.conventionalcommits.org/en/v1.0.0/). Write your commit message in the imperative: "Fix bug" and not "Fixed bug" or "Fixes bug." This convention matches up with commit messages generated by commands like `git merge` and `git revert`.
-Once you are done, please create a [pull request](https://github.com/engineervix/readme-coverage-badger/pulls).
+  Once you are done, please create a [pull request](https://github.com/engineervix/readme-coverage-badger/pulls).
 
 ## Show your support
 
@@ -201,15 +202,15 @@ Please give a ⭐️ if this project helped you!
 - [ ] Provide option to generate badge in HTML format
 - [ ] Provide option to generate to `stdout` and skip substitution in a README file. This could be useful if you're using the tool in a script and you just want the result so that you can use it elsewhere.
 - [ ] Allow for flexibility in choosing whatever colours one wants
-- [ ] Allow for specifying *Alt Text* on the badge URL, for example `![Alt Text]()` or `![Alt Text](anything here)`
+- [ ] Allow for specifying _Alt Text_ on the badge URL, for example `![Alt Text]()` or `![Alt Text](anything here)`
 - [ ] Make the codebase fully typed
 - [ ] Improve the Tests by [parametrizing](https://docs.pytest.org/en/stable/example/parametrize.html) fixtures and test functions
-- [X] improve CI/CD to cater for GNU/Linux, Mac OS X and Windows
+- [x] improve CI/CD to cater for GNU/Linux, Mac OS X and Windows
 - [ ] Create pre-commit hook
 
 ### docs
 
-- [X] Add a screenshot / demo in this README
+- [x] Add a screenshot / demo in this README
 - [ ] Create standalone documentation for hosting either on Github Pages or readthedocs. This README is already detailed enough to serve as documentation!
 
 ### other
@@ -218,10 +219,12 @@ Please give a ⭐️ if this project helped you!
 
 ## 📝 License
 
-Copyright © 2021 [Victor Miti](https://github.com/engineervix).
+Copyright © 2021 - present [Victor Miti](https://github.com/engineervix).
 
 This project is licensed under the terms of the [BSD-3-Clause](https://github.com/engineervix/readme-coverage-badger/blob/main/LICENSE) license.
 
-***
+---
+
 _This README was generated with ❤️ by [readme-md-generator](https://github.com/kefranabg/readme-md-generator)_
-***
+
+---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 
 [tool.isort]

--- a/readme_coverage_badger/__main__.py
+++ b/readme_coverage_badger/__main__.py
@@ -28,16 +28,19 @@ from urllib.parse import quote
 import coverage
 
 # other external dependency
-from colorama import Fore, Style, init
+from colorama import Back, Fore, Style, just_fix_windows_console
 
 # specify colors for different logging levels
 LOG_COLORS = {
-    # logging.DEBUG: Fore.WHITE,
+    logging.DEBUG: Fore.CYAN,
     logging.INFO: Fore.GREEN,
     logging.WARNING: Fore.YELLOW,
     logging.ERROR: Fore.RED,
-    # logging.CRITICAL: Fore.RED,
+    logging.CRITICAL: Fore.RED + Back.WHITE,
 }
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class ColourFormatter(logging.Formatter):
@@ -47,7 +50,7 @@ class ColourFormatter(logging.Formatter):
         https://uran198.github.io/en/python/2016/07/12/colorful-python-logging.html
     """
 
-    def format(self, record, *args, **kwargs):
+    def format(self, record):
         """
         if the corresponding logger has children, they may receive modified
         record, so we want to keep it intact
@@ -60,8 +63,8 @@ class ColourFormatter(logging.Formatter):
                 color_begin=LOG_COLORS[new_record.levelno],
                 color_end=Style.RESET_ALL,
             )
-        # now we can let standart formatting take care of the rest
-        return super(ColourFormatter, self).format(new_record, *args, **kwargs)
+        # now we can let standard formatting take care of the rest
+        return super().format(new_record)
 
 
 class Devnull(object):
@@ -77,17 +80,13 @@ class Devnull(object):
 
 def configure_logging():
     """Logging configuration for the project"""
-    logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
 
     # we want to display levelname, asctime and message
     formatter = ColourFormatter(
         "%(levelname)-12s: %(asctime)-8s %(message)s", datefmt="%d-%b-%y %H:%M:%S"
     )
-
-    # this handler will write to sys.stdout by default
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.DEBUG)
     handler.setFormatter(formatter)
 
     # adding handler to our logger
@@ -236,9 +235,6 @@ def update_coverage_badge(readme: str, cov_string: str, plain: Optional[bool] = 
 def main(args=None):
     """Console script entry point"""
 
-    init()
-    configure_logging()
-
     if not args:
         args = sys.argv[1:]
 
@@ -294,4 +290,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
+    just_fix_windows_console()
+    configure_logging()
     main()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,23 +1,24 @@
 # core
-colorama==0.4.4
-coverage==5.5
+colorama==0.4.6
+coverage==7.5.4
 
 # dev
-black==21.12b0
-commitizen==2.20.4
-flake8==4.0.1
-invoke==1.6.0
-isort==5.10.1
-mypy==0.931
-pre-commit==2.17.0
+black==24.4.2
+commitizen==3.27.0
+flake8==7.1.0
+invoke==2.2.0
+isort==5.13.2
+mypy==1.10.1
+pre-commit==3.5.0; python_version=='3.8'
+pre-commit==3.7.1; python_version>'3.8'
 
 # test
-faker==11.3.0
-pytest-cov==3.0.0
-pytest-mock==3.6.1
-pytest-sugar==0.9.4
-tox==3.24.5
+faker==26.0.0
+pytest-cov==5.0.0
+pytest-mock==3.14.0
+pytest-sugar==1.0.0
+tox==4.16.0
 
 # dist
-build==0.7.0
-twine==3.7.1
+build==1.2.1
+twine==5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,13 @@ description = automatically generates your project's coverage badge using the sh
 long_description = file: README.md, CHANGELOG.md, LICENSE
 long_description_content_type = text/markdown; charset=UTF-8
 author = Victor Miti
-author_email = victormiti@umusebo.com
+author_email = hello@victor.co.zm
 keywords = coverage badge shield readme
 license = BSD 3-Clause License
 url = https://github.com/engineervix/readme-coverage-badger/
 platforms = any
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
@@ -19,11 +19,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Testing
     Topic :: Text Processing :: Markup :: Markdown
     Topic :: Utilities
@@ -37,10 +37,10 @@ project_urls =
 [options]
 packages = readme_coverage_badger
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
     colorama
-    coverage <6
+    coverage
 
 [options.entry_points]
 console_scripts =
@@ -94,16 +94,16 @@ testpaths = tests
 # --- tox automation configuration -------------------------------------------
 
 [tox:tox]
-envlist = lint, py36, py37, py38, py39, py310
+envlist = lint, py38, py39, py310, py311, py312
 isolated_build = True
 
 [gh-actions]
 python =
+    3.12: lint, py312
+    3.11: py311
     3.10: py310
     3.9: py39
-    3.8: lint, py38
-    3.7: py37
-    3.6: py36
+    3.8: py38
 
 [testenv:lint]
 skip_install = True

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 import os
 
-from colorama import Fore, init
+from colorama import Fore, just_fix_windows_console
 from invoke import task
 
 # from pathlib import Path
@@ -166,7 +166,7 @@ def bump(c):
     First we check that there are no unstaged files in your repo before running
     """
 
-    init()
+    just_fix_windows_console()
 
     # TODO: this can be part of the "release" collection, where we bump, build and release
     unstaged_str = "not staged for commit"

--- a/tests/test_readme_coverage_badger.py
+++ b/tests/test_readme_coverage_badger.py
@@ -68,11 +68,11 @@ def test_successful_readme_coverage_badger(fake_readme, cb, caplog, monkeypatch)
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    cb.init()
+    cb.just_fix_windows_console()
     cb.configure_logging()
     cb.main([])
-    caplog.set_level(logging.DEBUG)
     for record in caplog.records:
         assert record.levelname == "INFO"
     assert (
@@ -90,11 +90,11 @@ def test_successful_readme_md_coverage_badger(fake_readme_md, cb, caplog, monkey
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    cb.init()
+    cb.just_fix_windows_console()
     cb.configure_logging()
     cb.main([])
-    caplog.set_level(logging.DEBUG)
     for record in caplog.records:
         assert record.levelname == "INFO"
     assert (
@@ -113,12 +113,13 @@ def test_no_readme_file(cb, caplog, monkeypatch):
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    cb.init()
+    cb.just_fix_windows_console()
     cb.configure_logging()
     with pytest.raises(SystemExit) as e:
         cb.main([])
-    caplog.set_level(logging.DEBUG)
+
     caplog_messages = [(record.levelname, record.msg) for record in caplog.records]
     valid_readmes = (
         f"{Fore.MAGENTA}README.md{Fore.RESET} or {Fore.MAGENTA}README{Fore.RESET}"
@@ -147,12 +148,13 @@ def test_readme_no_replacement_string(
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    cb.init()
+    cb.just_fix_windows_console()
     cb.configure_logging()
     with pytest.raises(SystemExit) as e:
         cb.main([])
-    caplog.set_level(logging.DEBUG)
+
     caplog_messages = [(record.levelname, record.msg) for record in caplog.records]
     empty_badge_pattern = "![Code Coverage]()"
     help_message = Fore.MAGENTA + empty_badge_pattern + Fore.RESET
@@ -179,12 +181,13 @@ def test_coverage_up_to_date(fake_readme_up_to_date, cb, caplog, monkeypatch):
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    cb.init()
+    cb.just_fix_windows_console()
     cb.configure_logging()
     with pytest.raises(SystemExit) as e:
         cb.main([])
-    caplog.set_level(logging.DEBUG)
+
     caplog_messages = [(record.levelname, record.msg) for record in caplog.records]
     assert (
         "INFO",
@@ -208,12 +211,13 @@ def test_no_coverage(fake_readme_md, no_total, caplog, monkeypatch):
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    no_total.init()
+    no_total.just_fix_windows_console()
     no_total.configure_logging()
     with pytest.raises(SystemExit) as excinfo:
         no_total.main([])
-    caplog.set_level(logging.DEBUG)
+
     caplog_messages = [(record.levelname, record.msg) for record in caplog.records]
     assert (
         "ERROR",
@@ -235,13 +239,13 @@ def test_coverage_is_none(fake_readme, cb, caplog, monkeypatch, mocker):
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
-    cb.init()
+    cb.just_fix_windows_console()
     cb.configure_logging()
     with pytest.raises(SystemExit) as excinfo:
         cb.main([])
 
-    caplog.set_level(logging.DEBUG)
     caplog_messages = [(record.levelname, record.msg) for record in caplog.records]
     availability = Fore.CYAN + str("coverage" in sys.modules) + Fore.RESET
     assert (
@@ -289,15 +293,16 @@ def test_plain_colour_mode(fake_readme, caplog, monkeypatch):
         return os.path.join(TESTS_DIR, readme_file)
 
     monkeypatch.setattr(__main__, "readme_location", fake_readme_location)
+    caplog.set_level(logging.DEBUG)
 
     default_colour = __main__.DEFAULT_COLOUR
     assert default_colour == "green"
     for total in ("97.89", "93", "80", "65", "45", "15", "n/a"):
         __main__.get_total = lambda: total
-        __main__.init()
+        __main__.just_fix_windows_console()
         __main__.configure_logging()
         __main__.main(["-p"])
-        caplog.set_level(logging.DEBUG)
+
         badge_url = f"https://img.shields.io/badge/Coverage-{total}{quote('%')}-{default_colour}.svg"
         with open(os.path.join(TESTS_DIR, readme_file), "r") as f:
             text = f.read()


### PR DESCRIPTION
I haven't touched this project in a while -- time to revive it!

Python 3.6 and 3.7 are no longer maintained. See https://endoflife.date/python

Even Python 3.8 will stop being maintained in a couple of months, but we can deal with that later.